### PR TITLE
Improve start command creating in tow.sh

### DIFF
--- a/tests/dockerfile_tests.py
+++ b/tests/dockerfile_tests.py
@@ -61,22 +61,22 @@ class DockerfileTest(unittest.TestCase):
     def test_find_entrypoint_or_cmd(self):
         d = Dockerfile("Dockerfile")
         d._Dockerfile__dockerfile = ['FROM ubuntu', 'ENTRYPOINT ["/bin/sh"]', 'CMD ["-c"]']
-        self.assertEqual(d.find_entrypoint_or_cmd(), ("/bin/sh", "-c"))
+        self.assertEqual(d.find_entrypoint_or_cmd(), (["/bin/sh"], ["-c"]))
 
     def test_find_entrypoint_or_cmd_shell_style(self):
         d = Dockerfile("Dockerfile")
         d._Dockerfile__dockerfile = ['FROM ubuntu', 'ENTRYPOINT /bin/sh', 'CMD ["-c"]']
-        self.assertEqual(d.find_entrypoint_or_cmd(), ("/bin/sh", "-c"))
+        self.assertEqual(d.find_entrypoint_or_cmd(), (["/bin/sh"], ["-c"]))
 
     def test_find_entrypoint_or_cmd_cmd_only(self):
         d = Dockerfile("Dockerfile")
         d._Dockerfile__dockerfile = ['FROM ubuntu', 'CMD ["/bin/sh", "-c", "-x"]']
-        self.assertEqual(d.find_entrypoint_or_cmd(), (None, "/bin/sh -c -x"))
+        self.assertEqual(d.find_entrypoint_or_cmd(), (None, ["/bin/sh", "-c", "-x"]))
 
     def test_find_entrypoint_or_cmd_entrypoint_only(self):
         d = Dockerfile("Dockerfile")
         d._Dockerfile__dockerfile = ['FROM ubuntu', 'ENTRYPOINT ["/bin/sh"]']
-        self.assertEqual(d.find_entrypoint_or_cmd(), ("/bin/sh", None))
+        self.assertEqual(d.find_entrypoint_or_cmd(), (["/bin/sh"], None))
 
     def test_find_entrypoint_or_cmd_none(self):
         d = Dockerfile("Dockerfile")

--- a/tow/commands/build.py
+++ b/tow/commands/build.py
@@ -31,11 +31,17 @@ class BuildCommand(Command):
         #  Check if you would like to patch Dockerfile in order to use
         #  reconfiguration on run phase
         if namespace.tow_run:
+            command = []
             (entrypoint, cmd) = dockerfile.find_entrypoint_or_cmd()
+            if cmd:
+                command += cmd
+            if entrypoint:
+                command = entrypoint + command
+                command.append("$@")
             templates.process_template("tow.sh.tmpl",
                                        os.path.join(workingdir, "tow.sh"),
-                                       {"entrypoint": entrypoint,
-                                        "cmd": cmd, "mapping": file_mapping,
+                                       {"command": command,
+                                        "mapping": file_mapping,
                                         "volume_name": TOW_VOLUME})
             file_mapping.append(("tow.sh", "/tow.sh", 755))
             dockerfile.replace_entrypoint_or_cmd_by_tow_cmd("sh /tow.sh")

--- a/tow/dockerfile.py
+++ b/tow/dockerfile.py
@@ -60,9 +60,9 @@ class Dockerfile(object):
             # Handle array command
             if command.startswith("[") and command.endswith("]"):
                 command = command[1:-1]
-                return " ".join([sh.strip()[1:-1] for sh in command.split(",")])
+                return [sh.strip()[1:-1] for sh in command.split(",")]
             else:  # It's just shell notation
-                return command.strip()
+                return [command.strip()]
         return None
 
     def envs(self):

--- a/tow/templates/tow.sh.tmpl
+++ b/tow/templates/tow.sh.tmpl
@@ -7,12 +7,4 @@ fi
 
 PATH=$PATH:`pwd`
 
-{% if entrypoint %}
-{% if cmd %}
-"{{entrypoint}}" "{{cmd}}" "$@"
-{% else %}
-"{{entrypoint}}" "$@"
-{% endif %}
-{% else %}
-"{{cmd}}"
-{% endif %}
+{% for cmd in command -%}"{{ cmd }}" {% endfor %}


### PR DESCRIPTION
- Fixed #60 
- Function _parse_exec_line now return array
- tow.sh.tmpl requires command variable instead of cmd and entrypoint
- command for tow.sh generates in build.py dependes on cmd and entrypoint
